### PR TITLE
Fix for Meteor 0.6.5 functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .npm
 .git
+.build*

--- a/package.js
+++ b/package.js
@@ -8,4 +8,7 @@ Npm.depends({
 
 Package.on_use(function (api, where) {
   api.add_files('winston.js', 'server');
+  if (api.export) {
+	api.export("Winston");
+  }
 });

--- a/smart.json
+++ b/smart.json
@@ -3,7 +3,7 @@
   "description": "Winston logging library, packaged for Meteor",
   "homepage": "https://github.com/tomrogers3/meteor-winston",
   "author": "Tom Rogers <tomrogers3@gmail.com>",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "git": "https://github.com/tomrogers3/meteor-winston.git",
   "packages": {}
 }


### PR DESCRIPTION
I added the api.export line so `Winston` is available for Meteor Apps 0.6.5+ and above. I also upped the smart.json version, so you could easily merge this pull request, then pull it down and run an `mrt release .` to update atmosphere.
